### PR TITLE
Feat: 지도 페이지 건물 상세 정보 탭

### DIFF
--- a/components/pages/map/DescriptionTab.tsx
+++ b/components/pages/map/DescriptionTab.tsx
@@ -1,0 +1,46 @@
+import { BuildingType, PopupType } from 'types/client.types';
+
+interface Props {
+  building: BuildingType;
+  closeTab: () => void;
+}
+
+const DescriptionTab = ({ building, closeTab }: Props) => {
+  return (
+    <div className='fixed bottom-0 left-0 top-0 z-popup w-372 overflow-y-auto bg-white p-32'>
+      <button
+        onClick={closeTab}
+        className='relative right-0 top-0 mb-12 h-24 w-24 rounded-full border border-gray-600 text-sm text-gray-600'
+      >
+        X
+      </button>
+      <div className='text-2xl font-bold'>{building.name}</div>
+      <div className='text-lg'>{building.address}</div>
+
+      <div className='flex flex-col gap-12 pt-24'>
+        <div className='text-sm text-gray-600'>
+          {building.popups.length}개의 팝업 이력이 있습니다.
+        </div>
+        {building.popups.map((popup) => (
+          <Popup key={popup.name} popup={popup} />
+        ))}
+      </div>
+    </div>
+  );
+};
+
+export default DescriptionTab;
+
+interface PopupProps {
+  popup: PopupType;
+}
+
+const Popup = ({ popup }: PopupProps) => {
+  return (
+    <div className='border border-black p-8'>
+      <div className='text-lg font-semibold'>{popup.name}</div>
+      <div className='text-sm'>{popup.date}</div>
+      <div className='text-sm'>{popup.address}</div>
+    </div>
+  );
+};

--- a/mock/popup.ts
+++ b/mock/popup.ts
@@ -1,6 +1,4 @@
-import { PopupType } from 'types/client.types';
-
-export const POPUP_MOCK_DATA: PopupType[] = [
+export const POPUP_MOCK_DATA = [
   {
     name: '서울국제소싱페어',
     date: '23.11.29 - 23.12.01',

--- a/pages/map.tsx
+++ b/pages/map.tsx
@@ -1,9 +1,9 @@
 import axios from 'axios';
 import { GUNGU, GUNGU_COORD, GunguType } from 'constants/regions';
-import { POPUP_MOCK_DATA } from 'mock/popup';
 import { ChangeEvent, SyntheticEvent, useState } from 'react';
 import useKakaoMap from 'hooks/useKakaoMap';
-import { BuildingsType, PopupType } from 'types/client.types';
+import { BuildingType } from 'types/client.types';
+import DescriptionTab from 'components/pages/map/DescriptionTab';
 
 export const getServerSideProps = async () => {
   const res = await axios(
@@ -27,11 +27,16 @@ const HOT_PLACE_COLOR = [
 ];
 
 interface Props {
-  buildings: BuildingsType[];
+  buildings: BuildingType[];
 }
 
 const MapPage = ({ buildings }: Props) => {
   const [map, setMap] = useState<any>();
+  const [descriptionTab, setDescriptionTab] = useState<BuildingType | null>();
+
+  const closeDescriptionTab = () => {
+    setDescriptionTab(null);
+  };
 
   const initMap = () => {
     window.kakao?.maps?.load(() => {
@@ -51,6 +56,11 @@ const MapPage = ({ buildings }: Props) => {
         const marker = new window.kakao.maps.Marker({
           map,
           position,
+          clickable: true,
+        });
+        window.kakao.maps.event.addListener(marker, 'click', () => {
+          console.log(building);
+          setDescriptionTab(building);
         });
         buildingMarkers.push(marker);
         marker.setMap(null);
@@ -90,6 +100,7 @@ const MapPage = ({ buildings }: Props) => {
           map,
           position: coord,
         });
+
         gunguMarkers.push(marker);
         marker.setMap(map);
 
@@ -173,30 +184,34 @@ const MapPage = ({ buildings }: Props) => {
   };
 
   return (
-    <>
-      <div className='relative h-screen w-screen'>
-        <form
-          onSubmit={handleClick}
-          className='w-250 fixed left-0 top-0 z-floating flex h-60 bg-transparent p-12'
-        >
-          <input
-            onChange={handleAddressChange}
-            placeholder='지역을 검색해보세요!'
-            className='h-full rounded-md border border-gray-400 p-4 shadow-md'
-          />
-          <button className='ml-4 h-full w-60 rounded-md border border-gray-400 bg-orange-400 shadow-md'>
-            검색
-          </button>
-        </form>
-        <div id='map' className='h-full w-full' />
-      </div>
-    </>
+    <div className='relative h-screen w-screen'>
+      {descriptionTab && (
+        <DescriptionTab
+          building={descriptionTab}
+          closeTab={closeDescriptionTab}
+        />
+      )}
+      <form
+        onSubmit={handleClick}
+        className='w-250 fixed left-0 top-0 z-nav flex h-60 bg-transparent p-12'
+      >
+        <input
+          onChange={handleAddressChange}
+          placeholder='지역을 검색해보세요!'
+          className='h-full rounded-md border border-gray-400 p-4 shadow-md'
+        />
+        <button className='ml-4 h-full w-60 rounded-md border border-gray-400 bg-orange-400 shadow-md'>
+          검색
+        </button>
+      </form>
+      <div id='map' className='h-full w-full' />
+    </div>
   );
 };
 
 export default MapPage;
 
-const getHotRate = (buildings: BuildingsType[]) => {
+const getHotRate = (buildings: BuildingType[]) => {
   const popupsInRegion = {
     강남구: 0,
     강동구: 0,

--- a/pages/map.tsx
+++ b/pages/map.tsx
@@ -59,7 +59,6 @@ const MapPage = ({ buildings }: Props) => {
           clickable: true,
         });
         window.kakao.maps.event.addListener(marker, 'click', () => {
-          console.log(building);
           setDescriptionTab(building);
         });
         buildingMarkers.push(marker);
@@ -99,6 +98,11 @@ const MapPage = ({ buildings }: Props) => {
         const marker = new window.kakao.maps.Marker({
           map,
           position: coord,
+        });
+
+        window.kakao.maps.event.addListener(marker, 'click', () => {
+          map.setLevel(6);
+          map.setCenter(coord);
         });
 
         gunguMarkers.push(marker);
@@ -243,7 +247,6 @@ const getHotRate = (buildings: BuildingType[]) => {
   buildings.forEach((building) => {
     const gungu = building.address.split(' ')[1] as GunguType;
     if (!building.popups) {
-      console.log(building);
       return;
     }
     popupsInRegion[gungu] += building.popups.length;

--- a/types/client.types.ts
+++ b/types/client.types.ts
@@ -1,8 +1,21 @@
 export interface PopupType {
   name: string;
-  date: string;
   address: string;
+  date: string;
+  building: string;
+  type: string;
+  keyword: string;
 }
+
+export interface BuildingsType {
+  id: number;
+  name: string;
+  address: string;
+  coord: string;
+  iscurrent: number;
+  popups: PopupType[];
+}
+
 export interface PopulationType {
   areaName: string;
   updateTime: string;

--- a/types/client.types.ts
+++ b/types/client.types.ts
@@ -7,7 +7,7 @@ export interface PopupType {
   keyword: string;
 }
 
-export interface BuildingsType {
+export interface BuildingType {
   id: number;
   name: string;
   address: string;


### PR DESCRIPTION
close #8 
## ✏️ 작업 내용

- 지도 페이지에서 건물 핀을 눌렀을 때 상세 탭이 뜨도록 구현했습니다.
- 지역 핀을 눌렀을 때 해당 지역으로 줌인 되도록 하였습니다.

## 📷 스크린샷

https://github.com/Neul-pum/PopPop/assets/83965026/a90dcfcf-81e9-4f54-87f1-b63d72398d17


