### PR TITLE
Feat: 프로필 컴포넌트

### DIFF
--- a/components/pages/mypage/Profile.tsx
+++ b/components/pages/mypage/Profile.tsx
@@ -1,0 +1,27 @@
+const Profile = () => {
+  return (
+    <div className='flex items-center justify-center gap-40'>
+      <div>
+        <input
+          type='file'
+          accept='image/jpg,impge/png,image/jpeg'
+          name='profile_img'
+          className='hidden'
+        />
+      </div>
+      <div className='flex flex-col gap-32'>
+        <div className='flex items-center gap-40'>
+          <div className='text-2xl font-bold'>송민혁</div>
+          <button className='rounded-lg bg-gray-100 p-8 hover:bg-gray-200'>
+            프로필 편집 버튼
+          </button>
+        </div>
+        <div className='h-100 w-500 rounded-lg bg-gray-100 p-16'>
+          소개문구랍니다.
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default Profile;

--- a/components/pages/mypage/Profile.tsx
+++ b/components/pages/mypage/Profile.tsx
@@ -1,5 +1,4 @@
 import Image from 'next/image';
-import { useRef, useState } from 'react';
 
 const defaultProfileImage =
   'https://cdn.pixabay.com/photo/2015/10/05/22/37/blank-profile-picture-973460_1280.png';
@@ -7,29 +6,6 @@ const defaultProfileImage =
 const CIRCLE_RADIUS = 152;
 
 const Profile = () => {
-  const [image, setImage] = useState('');
-  const fileInput = useRef<HTMLInputElement>(null);
-
-  const handelClickImg = () => {
-    if (fileInput.current) fileInput.current.click();
-  };
-
-  const onChange = (e: React.ChangeEvent<HTMLInputElement>) => {
-    const file = e.target.files?.[0];
-    if (file) {
-      const reader = new FileReader();
-      reader.onloadend = () => {
-        setImage(reader.result as string);
-      };
-      reader.readAsDataURL(file);
-      reader.onload = () => {
-        if (reader.readyState === 2) {
-          setImage(reader.result as string);
-        }
-      };
-    }
-  };
-
   return (
     <div className='flex items-center justify-center gap-40'>
       <div>
@@ -37,20 +13,11 @@ const Profile = () => {
           <Image
             width={CIRCLE_RADIUS}
             height={CIRCLE_RADIUS}
-            src={image || defaultProfileImage}
+            src={defaultProfileImage}
             alt='프로필 사진'
-            onClick={handelClickImg}
-            className='cursor-pointer rounded-full'
+            className='cursor-pointer rounded-full bg-cover'
           />
         </div>
-        <input
-          ref={fileInput}
-          type='file'
-          accept='image/jpg,impge/png,image/jpeg'
-          name='profile_img'
-          onChange={onChange}
-          className='hidden'
-        />
       </div>
       <div className='flex flex-col gap-32'>
         <div className='flex items-center gap-40'>

--- a/components/pages/mypage/Profile.tsx
+++ b/components/pages/mypage/Profile.tsx
@@ -1,33 +1,39 @@
-import Image from 'next/image';
+import Image, { StaticImageData } from 'next/image';
 
-const defaultProfileImage =
+const DEFAULT_PROFILE_IMAGE =
   'https://cdn.pixabay.com/photo/2015/10/05/22/37/blank-profile-picture-973460_1280.png';
 
 const CIRCLE_RADIUS = 152;
 
-const Profile = () => {
+const Profile = (props: {
+  profileImage?: string | StaticImageData;
+  nickname: string;
+  introduction?: string;
+}) => {
+  const { profileImage, nickname, introduction } = props;
   return (
     <div className='flex items-center justify-center gap-40'>
-      <div>
-        <div className={`w-${CIRCLE_RADIUS} h-${CIRCLE_RADIUS}`}>
-          <Image
-            width={CIRCLE_RADIUS}
-            height={CIRCLE_RADIUS}
-            src={defaultProfileImage}
-            alt='프로필 사진'
-            className='cursor-pointer rounded-full bg-cover'
-          />
-        </div>
+      <div
+        className={`flex items-center justify-center overflow-hidden rounded-full`}
+      >
+        <Image
+          width={CIRCLE_RADIUS}
+          height={CIRCLE_RADIUS}
+          src={profileImage || DEFAULT_PROFILE_IMAGE}
+          alt='프로필 사진'
+          className='rounded-full object-cover'
+        />
       </div>
       <div className='flex flex-col gap-32'>
         <div className='flex items-center gap-40'>
-          <div className='text-2xl font-bold'>송민혁</div>
+          <div className='text-2xl font-bold'>{nickname}</div>
+          {/* TODO: 프로필 편집 페이지로 이동 */}
           <button className='rounded-lg bg-gray-100 p-8 hover:bg-gray-200'>
             프로필 편집
           </button>
         </div>
         <div className='h-100 w-500 rounded-lg bg-gray-100 p-16'>
-          소개문구랍니다.
+          {introduction}
         </div>
       </div>
     </div>

--- a/components/pages/mypage/Profile.tsx
+++ b/components/pages/mypage/Profile.tsx
@@ -1,11 +1,54 @@
+import Image from 'next/image';
+import { useRef, useState } from 'react';
+
+const defaultProfileImage =
+  'https://cdn.pixabay.com/photo/2015/10/05/22/37/blank-profile-picture-973460_1280.png';
+
+const CIRCLE_RADIUS = 152;
+
 const Profile = () => {
+  const [image, setImage] = useState('');
+  const fileInput = useRef<HTMLInputElement>(null);
+
+  const handelClickImg = () => {
+    if (fileInput.current) fileInput.current.click();
+  };
+
+  const onChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const file = e.target.files?.[0];
+    if (file) {
+      const reader = new FileReader();
+      reader.onloadend = () => {
+        setImage(reader.result as string);
+      };
+      reader.readAsDataURL(file);
+      reader.onload = () => {
+        if (reader.readyState === 2) {
+          setImage(reader.result as string);
+        }
+      };
+    }
+  };
+
   return (
     <div className='flex items-center justify-center gap-40'>
       <div>
+        <div className={`w-${CIRCLE_RADIUS} h-${CIRCLE_RADIUS}`}>
+          <Image
+            width={CIRCLE_RADIUS}
+            height={CIRCLE_RADIUS}
+            src={image || defaultProfileImage}
+            alt='프로필 사진'
+            onClick={handelClickImg}
+            className='cursor-pointer rounded-full'
+          />
+        </div>
         <input
+          ref={fileInput}
           type='file'
           accept='image/jpg,impge/png,image/jpeg'
           name='profile_img'
+          onChange={onChange}
           className='hidden'
         />
       </div>
@@ -13,7 +56,7 @@ const Profile = () => {
         <div className='flex items-center gap-40'>
           <div className='text-2xl font-bold'>송민혁</div>
           <button className='rounded-lg bg-gray-100 p-8 hover:bg-gray-200'>
-            프로필 편집 버튼
+            프로필 편집
           </button>
         </div>
         <div className='h-100 w-500 rounded-lg bg-gray-100 p-16'>

--- a/components/pages/mypage/Profile.tsx
+++ b/components/pages/mypage/Profile.tsx
@@ -14,14 +14,13 @@ const Profile = (props: {
   return (
     <div className='flex items-center justify-center gap-40'>
       <div
-        className={`flex items-center justify-center overflow-hidden rounded-full`}
+        className={`relative h-${CIRCLE_RADIUS} w-${CIRCLE_RADIUS} overflow-hidden rounded-full`}
       >
         <Image
-          width={CIRCLE_RADIUS}
-          height={CIRCLE_RADIUS}
           src={profileImage || DEFAULT_PROFILE_IMAGE}
           alt='프로필 사진'
-          className='rounded-full object-cover'
+          fill
+          className='object-cover'
         />
       </div>
       <div className='flex flex-col gap-32'>


### PR DESCRIPTION
## ✏️ 작업 내용
- 마이페이지에 있는 프로필 관련 컴포넌트를 만들었습니다.
- 변경된 타입 컨벤션 적용
- 아직 디자인이 확정적으로 안 나와서 내용이 부실한 점이 있습니다.

## 📷 스크린샷
![image](https://github.com/Neul-pum/PopPop/assets/98685266/9fe601fe-fadf-4818-8a73-ebf2ca7323e8)

## ✍️ 사용법
```js
<Profile
  nickname={'송민혁'}
  introduction={'반가워요'}
  profileImage={ProfileMockImage}
/>
```

## 🎸 기타
프로필 이미지가 이미지 크기와 상관없이 둥글게 나와야 하는데 가로세로 비율이 각기 다른 이미지가 둥근 컨테이너에 맞춰지도록 하는 css 를 코드를 알고 싶은데 알려주시겠나요?

추가적으로 프로필 편집 페이지에서 프로필 이미지 및 내용 변경이 가능한데.. 제가 헷갈리고 바깥에서도 수정된다는 생각을 해서 미리보기 기능을 넣었다가 뺐습니다. 그래서 commit에서 혼동될 수 있다는 점 양해 부탁드려요.

close #14 