### PR TITLE
Fix: Enter 키로 관심분야 태그 등록 기능 수정

### DIFF
--- a/components/commons/modals/ProfileEditModal.tsx
+++ b/components/commons/modals/ProfileEditModal.tsx
@@ -55,15 +55,13 @@ const ProfileEditModal = (props: {
   };
 
   // 태그
-  const [tags, setTags] = useState<string[] | undefined>(
-    userInfo?.tag?.split(','),
-  );
+  const [tags, setTags] = useState<string[]>(userInfo?.tag?.split(',') || []);
   const [tagText, setTagText] = useState<string>('');
 
   const addTags = (e: KeyboardEvent<HTMLInputElement>) => {
     const inputVal = (e.target as HTMLInputElement).value;
     if (e.key === 'Enter' && inputVal !== '' && !tags?.includes(inputVal)) {
-      if (tags) setTags([...tags, inputVal]);
+      setTags([...tags, inputVal]);
       setTagText('');
     }
   };
@@ -103,7 +101,7 @@ const ProfileEditModal = (props: {
   };
 
   return (
-    <form className='flex h-full w-600 flex-col gap-8 rounded-24 p-24 md:w-full'>
+    <div className='flex h-full w-600 flex-col gap-8 rounded-24 p-24 md:w-full'>
       <div className='text-24 font-800'>프로필 편집</div>
       <div className='relative mb-8 h-64 w-64 rounded-full'>
         <input
@@ -169,7 +167,7 @@ const ProfileEditModal = (props: {
           저장
         </button>
       </div>
-    </form>
+    </div>
   );
 };
 

--- a/components/commons/modals/ProfileModal.tsx
+++ b/components/commons/modals/ProfileModal.tsx
@@ -38,6 +38,7 @@ const ProfileModal = (props: {
 
   const { setSession } = useSession();
 
+  // 태그
   const [tags, setTags] = useState<string[]>([]);
   const [tagText, setTagText] = useState('');
 
@@ -54,6 +55,7 @@ const ProfileModal = (props: {
     setTags(filteredTags);
   };
 
+  // 닉네임
   const handleChangeNickname = (e: ChangeEvent<HTMLInputElement>) => {
     const newNickname = e.target.value;
     setValue('nickname', newNickname);
@@ -64,6 +66,7 @@ const ProfileModal = (props: {
     setValue('nickname', randomNickname);
   };
 
+  // 폼 제출
   const patchUserInfo: SubmitHandler<FormValues> = async (formData) => {
     const formDataResult = { ...formData, interests: tags.join(',') };
 


### PR DESCRIPTION
## ✏️ 작업 내용

- 엔터키로 폼 제출하는 걸 방지하기 위해 태그 수정  (form 태그 -> div 태그)
- 비동기로 불러오는 유저 정보로 인한 undefined 방어로 인한 태그 등록이 안 되었는데, 초기 데이터인 빈 배열을 넣음으로써 setTags 정상 작동

## 📷 스크린샷

https://github.com/user-attachments/assets/f9363db2-cedb-4b73-9388-f6f8c72ea342


